### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/OnPullToMain.yml
+++ b/.github/workflows/OnPullToMain.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build on PR to Main
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/joelbyford/DepCalcsCS/security/code-scanning/1](https://github.com/joelbyford/DepCalcsCS/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the `GITHUB_TOKEN` permissions. Since the workflow only checks out code and builds it, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
